### PR TITLE
[Fix] preview 배포에서 SPA 라우팅을 위한 vercel.json 추가

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
## ✨ 작업 내용

<!-- 어떤 작업을 했는지 간단히 작성해주세요 -->

현재 Vercel 배포페이지에서 주소창에 링크를 검색하여 들어가면 조회가 안되는 문제가 있습니다.
- Vercel Preview 환경에서 `/list` 등 직접 경로 접근 시 발생하는 404 문제를 해결하기 위해 `vercel.json` 파일을 추가했습니다.


### 💡 참고
Vercel은 정적 호스팅 서버이기 때문에:

1. 사용자가 /list로 직접 접근하면
2. Vercel 서버가 실제로 존재하는 list.html 파일을 찾음
3. 없으면 404를 반환함
4. 반면 React Router는 index.html 안에서만 라우팅을 제어함
→ npm run dev로 돌리는 로컬 환경에서는 정상

해결 방법: vercel.json에 "rewrites" 설정 추가
```json
{
  "rewrites": [
    { "source": "/(.*)", "destination": "/" }
  ]
}
```
이렇게 하면 모든 경로를 index.html로 리다이렉트해주고,
React Router가 나머지 경로를 처리하게 됩니다.

## 🔗 관련 이슈

<!-- 예: Fixes #1 (머지 시 이슈 자동 종료) -->

Fixes #
