### PR TITLE
Editor 및 ContentViewer의 스타일 적용 문제 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "dompurify": "^3.2.6",
         "emoji-picker-react": "^4.12.2",
         "eslint-plugin-react": "^7.37.5",
+        "html-truncate": "^1.2.2",
         "lexical": "^0.32.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -3797,6 +3798,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-truncate": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/html-truncate/-/html-truncate-1.2.2.tgz",
+      "integrity": "sha512-oiXb65RDxSYY8eXJKJiKHHpI7LyQbMG8LbSuvvWLLxAKNywJ7aaq0M1ynj2QJs0odQNggEEg/dTFVtH3lG0ClQ==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/husky": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dompurify": "^3.2.6",
     "emoji-picker-react": "^4.12.2",
     "eslint-plugin-react": "^7.37.5",
+    "html-truncate": "^1.2.2",
     "lexical": "^0.32.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/components/CardModal.jsx
+++ b/src/components/CardModal.jsx
@@ -1,9 +1,10 @@
 import styles from './CardModal.module.scss';
 import Modal from '@/components/Modal';
 import SenderProfile from '@/components/SenderProfile';
-
+import Editor from '@/components/Editor/Editor';
+import { FONT_STYLES } from '@/constants/fontMap';
 const CardModal = ({ modalItems, onClose }) => {
-  const { sender, imageUrl, createdAt, content } = modalItems;
+  const { sender, imageUrl, createdAt, content, font } = modalItems;
 
   return (
     <Modal className={styles['modal-styler']}>
@@ -12,7 +13,9 @@ const CardModal = ({ modalItems, onClose }) => {
       </Modal.headerArea>
       <Modal.divider />
       <Modal.contentArea>
-        <span className={styles['content']}>{content}</span>
+        <div className={styles['content']}>
+          <Editor content={content} readOnly font={font} />
+        </div>
       </Modal.contentArea>
       <Modal.buttonArea className={styles['button-area']}>
         <button onClick={onClose}>확인</button>

--- a/src/components/ContentViewer/ContentViewer.jsx
+++ b/src/components/ContentViewer/ContentViewer.jsx
@@ -2,6 +2,8 @@
 
 import React, { useMemo } from 'react';
 import DOMPurify from 'dompurify';
+import truncate from 'html-truncate';
+import { getFontStyle } from '@/constants/fontMap';
 
 /**
  * 안전한 HTML 뷰어
@@ -11,26 +13,26 @@ import DOMPurify from 'dompurify';
  * @param {number} [props.maxLength] - 최대 텍스트 길이(초과 시 말줄임). 기본값: 무제한
  * @param {string} [props.className] - 최외곽 wrapper에 추가할 CSS 클래스
  * @param {React.CSSProperties} [props.style] - wrapper에 추가할 인라인 스타일
+ * @param {string} [props.font='Pretendard'] - 폰트 이름 (기본: Pretendard)
  */
-export default function ContentViewer({ content = '', maxLength, className = '', style = {} }) {
+export default function ContentViewer({
+  content = '',
+  maxLength,
+  className = '',
+  style = {},
+  font = 'Pretendard',
+}) {
   // 1) XSS 방지용으로 HTML 소독
   const sanitizedHtml = useMemo(() => DOMPurify.sanitize(content), [content]);
 
   // 2) 텍스트만 추출해서 maxLength 초과 시 말줄임 처리
   const displayedHtml = useMemo(() => {
-    if (typeof maxLength !== 'number') {
-      return sanitizedHtml;
-    }
-    const div = document.createElement('div');
-    div.innerHTML = sanitizedHtml;
-    const text = div.textContent || '';
-    if (text.length <= maxLength) {
-      return sanitizedHtml;
-    }
-    // 포맷 유지 없이 텍스트만 슬라이스하여 말줄임
-    return `<p>${text.slice(0, maxLength)}…</p>`;
+    if (typeof maxLength !== 'number') return sanitizedHtml;
+    // truncate 라이브러리로 HTML을 최대 길이로 자름
+    return truncate(sanitizedHtml, maxLength, { ellipsis: '…' });
   }, [sanitizedHtml, maxLength]);
 
+  const fontStyle = getFontStyle(font);
   return (
     <div
       className={className}
@@ -39,6 +41,7 @@ export default function ContentViewer({ content = '', maxLength, className = '',
         overflow: 'auto',
         whiteSpace: 'pre-wrap',
         wordBreak: 'break-word',
+        ...fontStyle,
         ...style,
       }}
     >

--- a/src/components/Editor/Editor.jsx
+++ b/src/components/Editor/Editor.jsx
@@ -8,8 +8,10 @@ import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
 import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { $generateHtmlFromNodes, $generateNodesFromDOM } from '@lexical/html';
+import { $getRoot } from 'lexical';
 import ToolbarPlugin from './Toolbar';
 import styles from './Editor.module.scss';
+import { getFontStyle } from '@/constants/fontMap';
 
 /**
  * 에디터 내용 변경 시 HTML을 상위(onUpdate)로 전달
@@ -35,8 +37,18 @@ function OnEditorChange({ onUpdate }) {
  * @param {string} content - 초기 HTML
  * @param {(html: string) => void} onUpdate - 변경된 HTML 콜백
  * @param {React.CSSProperties} [style] - 에디터 스타일
+ * @param {string} [font='Pretendard'] - 에디터 폰트 (기본: Pretendard)
+ * @param {string} [className=''] - 최외곽 wrapper에 추가할 CSS 클래스
+ * @param {boolean} [readOnly=false] - 읽기 전용 모드 여부
  */
-export default function Editor({ content = '', onUpdate, style = {} }) {
+export default function Editor({
+  content = '',
+  onUpdate = () => {},
+  style = {},
+  readOnly = false,
+  font = 'Pretendard',
+  className = '',
+}) {
   // 1) theme: 텍스트 포맷 → CSS 클래스 매핑
   const theme = {
     text: {
@@ -47,37 +59,58 @@ export default function Editor({ content = '', onUpdate, style = {} }) {
     },
   };
 
-  // 2) initialEditorState: content가 있으면 파싱해서 노드 트리로 초기화
+  // 2) initialEditorState: content가 있으면 파싱해서 DOM => 노드 트리로 초기화
   const initialEditorState = useMemo(() => {
     if (!content) return null;
     const dom = new DOMParser().parseFromString(content, 'text/html');
-    return (editor) => $generateNodesFromDOM(editor, dom);
+
+    return (editor) => {
+      editor.update(() => {
+        const nodes = $generateNodesFromDOM(editor, dom); // DOM에서 노드 생성
+        const root = $getRoot(); // 현재 에디터의 루트 노드 가져오기
+        root.clear(); // 기존 내용 삭제 (필요 없으면 제거)
+        root.append(...nodes); // 파싱된 노드 삽입
+      });
+    };
   }, [content]);
 
   // 3) initialConfig: LexicalComposer에 전달할 초기 설정
   const initialConfig = {
-    namespace: 'MessageEditor',
-    theme,
-    initialEditorState,
+    namespace: 'MessageEditor', // 네임스페이스 설정
+    theme, // 에디터 테마 설정
+    editorState: initialEditorState, // 초기 에디터 상태 설정
+    editable: !readOnly, // 읽기 전용 모드 설정
     onError(error) {
       console.error('Lexical Error:', error);
     },
   };
+  // 4) 폰트 스타일 가져오기
+  const fontStyles = getFontStyle(font);
 
   return (
-    <div style={style}>
+    <div
+      className={className}
+      style={{
+        ...fontStyles,
+        ...style,
+      }}
+    >
       <LexicalComposer initialConfig={initialConfig}>
-        <ToolbarPlugin />
+        {!readOnly && <ToolbarPlugin />}
 
         {/* RichTextPlugin 하나로 bold/italic/underline/strikethrough 지원 */}
         <RichTextPlugin
           contentEditable={<ContentEditable className={styles.editor__content} />}
-          placeholder={<div className={styles.editor__placeholder}>내용을 입력해 주세요…</div>}
+          placeholder={
+            readOnly ? null : (
+              <div className={styles.editor__placeholder}>내용을 입력해 주세요…</div>
+            )
+          }
           ErrorBoundary={LexicalErrorBoundary}
         />
 
-        <HistoryPlugin />
-        <OnEditorChange onUpdate={onUpdate} />
+        {!readOnly && <HistoryPlugin />}
+        {!readOnly && <OnEditorChange onUpdate={onUpdate} />}
       </LexicalComposer>
     </div>
   );

--- a/src/constants/fontMap.js
+++ b/src/constants/fontMap.js
@@ -45,3 +45,27 @@ export const FONT_DROPDOWN_ITEMS = FONT_OPTIONS.map((fontName) => ({
     fontFamily: FONT_STYLES[fontName].fontFamily,
   },
 }));
+
+/**
+ * getFontStyle: 폰트 이름에 해당하는 스타일 객체를 반환
+ * - 폰트 이름이 FONT_STYLES에 없으면 기본 폰트(Noto Sans) 스타일 반환
+ * @param {*} fontName
+ */
+
+export function getFontStyle(fontName) {
+  if (FONT_STYLES[fontName]) {
+    return FONT_STYLES[fontName];
+  }
+  // 없다면 에러 던짐
+  throw new Error(`존재하지 않는 폰트 : ${fontName}`);
+}
+
+/**
+ * getFontFamily: 폰트 이름에 해당하는 fontFamily 값을 반환
+ * - 폰트 이름이 FONT_STYLES에 없으면 기본 폰트(Noto Sans) 스타일 반환
+ * @param {string} fontName
+ * @returns {string}
+ */
+export function getFontFamily(fontName) {
+  return getFontStyle(fontName).fontFamily;
+}

--- a/src/pages/MessagePage/MessagePage.jsx
+++ b/src/pages/MessagePage/MessagePage.jsx
@@ -127,7 +127,7 @@ function MessagePage() {
             <Editor
               content={values.content}
               onUpdate={handleChange('content')}
-              style={{ fontFamily: FONT_STYLES[values.font].fontFamily }}
+              font={values.font}
             />
           </div>
         </div>

--- a/src/pages/RollingPaperItemPage/components/ListCard.jsx
+++ b/src/pages/RollingPaperItemPage/components/ListCard.jsx
@@ -1,10 +1,11 @@
 import styles from './ListCard.module.scss';
 import DeleteIcon from './DeleteIcon';
 import SenderProfile from '@/components/SenderProfile';
-
+import ContentViewer from '@/components/ContentViewer/ContentViewer';
+import { FONT_STYLES } from '@/constants/fontMap';
 const ListCard = ({ cardData, showDelete, onClick, onDelete }) => {
   /* 폰트 확인 후 해당 폰트로 보여줘야 함 */
-  const { id, sender, profileImageURL, content, createdAt, relationship } = cardData;
+  const { id, sender, profileImageURL, content, createdAt, relationship, font } = cardData;
 
   const formatDateKRW = (isoString) => {
     const date = new Date(isoString);
@@ -41,7 +42,9 @@ const ListCard = ({ cardData, showDelete, onClick, onDelete }) => {
             )}
           </header>
           <hr className={styles['card__divider']} />
-          <section className={styles['card__content']}>{content}</section>
+          <section className={styles['card__content']}>
+            <ContentViewer content={content} font={font} />
+          </section>
         </div>
         <footer className={styles['card__date']}>{formatDateKRW(createdAt)}</footer>
       </div>


### PR DESCRIPTION
## ✨ 작업 내용


### Editor 컴포넌트
<img width="570" alt="image" src="https://github.com/user-attachments/assets/48ead646-3166-4973-a085-1439bb2b5a6d" />

> readOnly가 적용된 Editor 컴포넌트를 사용한 Modal

- editorState 키로 초기화 콜백을 전달하도록 수정했습니다.(읽기 모드 / 수정 모드에서 노드 트리가 불러와지지 않던 오류 수정)
- font prop을 통해서 font 만 전달해도 바로 폰트가 적용됩니다. ex) font: 'Pretendard'
- readOnly 모드를 지원하여, Editor 컴포넌트로도 content를 볼 수 있습니다.
#### 예시
``` jsx
<Editor content={content} readOnly font={font} />
```

---

### ContentViewer 컴포넌트
<img width="1217" alt="image" src="https://github.com/user-attachments/assets/5f1cc97a-8e01-41d5-aeb8-ff31513ede7e" />

> ContetViewer가 적용된 ListCard 예시 입니다.

- 직접 구현한 HTML-aware truncation 대신, html-truncate 라이브러리를 적용하여, 안전하에 파싱합니다.
-maxLen을 통해서 뷰어에 표시할 글자 수를 지정할 수 있습니다.
- 동일하게 font Prop을 지원합니다.
#### 예시
```jsx
<ContentViewer content={content} font={font} />
```

---

### FontMap 수정
- 폰트 매핑 상수(fontMap.js)에 getFontStyle, getFontFamily 헬퍼 함수 추가

### 나눔손글씨 폰트 수정
- 해당 폰트를 오류가 나지 않도록 새 폰트 파일로 교체했습니다.

---

## 참고
### 읽기 전용 Editor:

- 풀 리치텍스트(볼드·이탤릭·표·코드 등) 완벽 지원

- 에디터 플러그인·스타일과 1:1 동기화

- 초기 로딩·번들 크기·마운트 비용 높음

### ContentViewer:

- 순수 HTML 렌더링 + 글자/라인 클램프

- 번들 작고 렌더링·업데이트 초경량, SSR 친화적

- 복잡한 플러그인·편집 기능 없음

## 🔗 관련 이슈


Fixes #75