### PR TITLE
[Feat] 무한스크롤 가로 스크롤 시 기능 추가, 가로 스크롤 컴포넌트 hideScroll props 추가, 삭제 모달 수정, 프로필 컴포넌트 수정

### DIFF
--- a/src/assets/styles/_reset.scss
+++ b/src/assets/styles/_reset.scss
@@ -116,3 +116,7 @@ table {
 hr {
   margin: 0;
 }
+
+a {
+  text-decoration: none;
+}

--- a/src/components/Dropdown/Dropdown.module.scss
+++ b/src/components/Dropdown/Dropdown.module.scss
@@ -14,13 +14,13 @@
     background-color: var(--color-white);
 
     &:hover {
-      border: 1px solid var(--color-gray-500);
+      border: 1px solid var(--color-purple-600);
       color: var(--color-gray-500);
     }
 
     &:focus,
     &:active {
-      border: 2px solid var(--color-gray-500);
+      border: 2px solid var(--color-purple-600);
       color: var(--color-gray-900);
     }
 

--- a/src/components/HorizontalScrollContainer/HorizontalScrollContainer.jsx
+++ b/src/components/HorizontalScrollContainer/HorizontalScrollContainer.jsx
@@ -11,11 +11,17 @@ import styles from './HorizontalScrollContainer.module.scss';
  *
  * @param {{
  *   children: React.ReactNode,
+ *   hideScroll: boolean          // 스크롤 표시 여부
  *   className?: string,          // 추가적인 클래스 네임 (선택)
  *   style?: React.CSSProperties, // inline style (선택)
  * }} props
  */
-export default function HorizontalScrollContainer({ children, className = '', style = {} }) {
+export default function HorizontalScrollContainer({
+  children,
+  hideScroll = true,
+  className = '',
+  style = {},
+}) {
   const containerRef = useRef(null);
 
   useEffect(() => {
@@ -38,7 +44,11 @@ export default function HorizontalScrollContainer({ children, className = '', st
   }, []);
 
   return (
-    <div ref={containerRef} className={`${styles['horizontal-scroll']} ${className}`} style={style}>
+    <div
+      ref={containerRef}
+      className={`${styles['horizontal-scroll']} ${hideScroll ? styles['horizontal-scroll--hide-scrollbar'] : ''} ${className}`}
+      style={style}
+    >
       {children}
     </div>
   );

--- a/src/components/HorizontalScrollContainer/HorizontalScrollContainer.module.scss
+++ b/src/components/HorizontalScrollContainer/HorizontalScrollContainer.module.scss
@@ -7,7 +7,9 @@
   align-items: center;
   overflow-x: auto;
   overflow-y: hidden;
+}
 
+.horizontal-scroll--hide-scrollbar {
   /* Firefox 스크롤바 숨김 */
   @supports (scrollbar-width: none) {
     scrollbar-width: none; /* Firefox 에서만 스크롤바 숨김 */

--- a/src/components/InfinityScrollWrapper/InfinityScrollWrapper.jsx
+++ b/src/components/InfinityScrollWrapper/InfinityScrollWrapper.jsx
@@ -1,7 +1,20 @@
 import styles from './InfinityScrollWrapper.module.scss';
 import { useEffect, useRef } from 'react';
 
-const InfinityScrollWrapper = ({ children, hasNext, callback }) => {
+/*
+  children: 자식 요소
+  hasNext: 다음 데이터가 있는 지 여부 (true, false)
+  callback: 스크롤 끝에 도달했을 때 수행할 메소드
+  isHorizontal: 무한 스크롤 가로 여부
+  scrollObserverRef: 스크롤 대상
+*/
+const InfinityScrollWrapper = ({
+  children,
+  hasNext,
+  callback,
+  isHorizontal = false,
+  scrollObserverRef,
+}) => {
   const observerRef = useRef(null);
 
   useEffect(() => {
@@ -14,7 +27,10 @@ const InfinityScrollWrapper = ({ children, hasNext, callback }) => {
     };
 
     /* 무한 스크롤 감시 */
-    const observer = new IntersectionObserver(onScroll, { threshold: 0.5 });
+    const observer = new IntersectionObserver(onScroll, {
+      threshold: 0.5,
+      root: scrollObserverRef?.current ?? null,
+    });
     const currentRef = observerRef.current;
     if (currentRef) {
       observer.observe(currentRef);
@@ -26,10 +42,10 @@ const InfinityScrollWrapper = ({ children, hasNext, callback }) => {
       }
       observer.disconnect();
     };
-  }, [observerRef, hasNext, callback]);
+  }, [observerRef, hasNext, callback, isHorizontal, scrollObserverRef]);
 
   return (
-    <div className={styles['container']}>
+    <div className={isHorizontal ? styles['container--horizontal'] : styles['container--vertical']}>
       {children}
       <div ref={observerRef} className={styles['container__observer']} />
     </div>

--- a/src/components/InfinityScrollWrapper/InfinityScrollWrapper.module.scss
+++ b/src/components/InfinityScrollWrapper/InfinityScrollWrapper.module.scss
@@ -1,5 +1,12 @@
 .container {
-  width: 100%;
+  &--vertical {
+    width: 100%;
+  }
+
+  &--horizontal {
+    display: flex;
+    flex-direction: row;
+  }
 }
 
 .container__observer {

--- a/src/components/SenderProfile.module.scss
+++ b/src/components/SenderProfile.module.scss
@@ -24,6 +24,13 @@
   font-weight: 400;
   font-size: 20px;
   line-height: 24px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  word-break: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  line-clamp: 1;
+  -webkit-box-orient: vertical;
 }
 
 .name {

--- a/src/hooks/useMessageItemsList.jsx
+++ b/src/hooks/useMessageItemsList.jsx
@@ -4,7 +4,6 @@ import { listRecipientMessages } from '@/apis/recipientMessageApi';
 import { deleteMessage } from '@/apis/messagesApi';
 import { deleteRecipient } from '@/apis/recipientsApi';
 import { getRecipient } from '@/apis/recipientsApi';
-import { COLOR_STYLES } from '@/constants/colorThemeStyle';
 
 export const useMessageItemsList = (id) => {
   /* useApi 사용하여 메시지 리스트 호출 */

--- a/src/hooks/useMessageItemsList.jsx
+++ b/src/hooks/useMessageItemsList.jsx
@@ -32,7 +32,8 @@ export const useMessageItemsList = (id) => {
   );
 
   const [showOverlay, setShowOverlay] = useState(false);
-  const isLoading = recipientDataLoading || messageLoading || deleteMessageLoading;
+  const isLoading =
+    recipientDataLoading || messageLoading || deleteMessageLoading || deleteRecipientLoading;
 
   const getLoadingDescription = () => {
     let description = '';

--- a/src/pages/ListPage/ListPage.jsx
+++ b/src/pages/ListPage/ListPage.jsx
@@ -8,6 +8,11 @@ import { listRecipients } from '../../apis/recipientsApi';
 import { useApi } from '../../hooks/useApi';
 
 const ListPage = () => {
+  /* 무한스크롤: Api 요청 데이터에서 next값이 있는지 확인, true 일때만 데이터를 불러옴 */
+  const hasNext = false;
+  /* 무한스크롤: 추가 데이터 로드 */
+  const loadMore = () => {};
+
   // 1) useApi로 전체 Recipient 목록(fetch) 요청
   const {
     data: listData,
@@ -47,7 +52,7 @@ const ListPage = () => {
       {/* 인기 롤링 페이퍼 🔥 */}
       <section className={styles['list-page__section']}>
         <h2 className={styles['list-page__title']}>인기 롤링 페이퍼 🔥</h2>
-        <Slider cards={popularCards} />
+        <Slider cards={popularCards} hasNext={hasNext} loadMore={loadMore} />
       </section>
 
       {/* 최근에 만든 롤링 페이퍼 ⭐️ */}

--- a/src/pages/ListPage/components/Slider.jsx
+++ b/src/pages/ListPage/components/Slider.jsx
@@ -10,13 +10,9 @@ const CARD_WIDTH = 275;
 const GAP = 16;
 const PAGE_SIZE = 4;
 
-const Slider = ({ cards }) => {
-  /* 무한 스크롤에서 스크롤 감지를 위함 */
+const Slider = ({ cards, hasNext, loadMore }) => {
+  /* 무한 스크롤: 스크롤 감지 ref 요소 전달 */
   const scrollObserverRef = useRef(null);
-  /* Api 요청 데이터에서 next값이 있는지 확인, true 일때만 데이터를 불러옴 */
-  const hasNext = true;
-  /* 추가 데이터 로드 */
-  const loadMore = () => {};
 
   const { wrapperRef, isDesktop, pageIndex, canPrev, canNext, goPrev, goNext } = useSliderPaging({
     totalItems: cards.length,

--- a/src/pages/ListPage/components/Slider.jsx
+++ b/src/pages/ListPage/components/Slider.jsx
@@ -1,14 +1,23 @@
+import { useRef } from 'react';
 import styles from './Slider.module.scss';
 import ItemCard from './ItemCard';
 import ArrowButton from '../../../components/Button/ArrowButton';
 import HorizontalScrollContainer from '../../../components/HorizontalScrollContainer/HorizontalScrollContainer';
 import { useSliderPaging } from '@/hooks/useSliderPaging';
+import InfinityScrollWrapper from '@/components/InfinityScrollWrapper/InfinityScrollWrapper';
 
 const CARD_WIDTH = 275;
 const GAP = 16;
 const PAGE_SIZE = 4;
 
 const Slider = ({ cards }) => {
+  /* 무한 스크롤에서 스크롤 감지를 위함 */
+  const scrollObserverRef = useRef(null);
+  /* Api 요청 데이터에서 next값이 있는지 확인, true 일때만 데이터를 불러옴 */
+  const hasNext = true;
+  /* 추가 데이터 로드 */
+  const loadMore = () => {};
+
   const { wrapperRef, isDesktop, pageIndex, canPrev, canNext, goPrev, goNext } = useSliderPaging({
     totalItems: cards.length,
     pageSize: PAGE_SIZE,
@@ -31,12 +40,14 @@ const Slider = ({ cards }) => {
       )}
 
       <div ref={wrapperRef} className={styles['slider__container']}>
-        <HorizontalScrollContainer>
-          <div className={styles['slider__track']}>
-            {visibleCards.map((c) => (
-              <ItemCard key={c.id} data={c} />
-            ))}
-          </div>
+        <HorizontalScrollContainer ref={scrollObserverRef} hideScroll={false}>
+          <InfinityScrollWrapper hasNext={hasNext} callback={loadMore} isHorizontal>
+            <div className={styles['slider__track']}>
+              {visibleCards.map((c) => (
+                <ItemCard key={c.id} data={c} />
+              ))}
+            </div>
+          </InfinityScrollWrapper>
         </HorizontalScrollContainer>
       </div>
 

--- a/src/pages/RollingPaperItemPage/RollingPaperItemPage.jsx
+++ b/src/pages/RollingPaperItemPage/RollingPaperItemPage.jsx
@@ -4,15 +4,16 @@ import { useApi } from '@/hooks/useApi.jsx';
 import { useModal } from '@/hooks/useModal';
 import { getRecipient } from '@/apis/recipientsApi';
 import { useMessageItemsList } from '@/hooks/useMessageItemsList';
-import { COLOR_STYLES } from '../../constants/colorThemeStyle';
-import styles from '@/pages/RollingPaperItemPage/RollingPaperItemPage.module.scss';
-import ListButtonGroup from './components/ListButtonGroup';
-import ListCard from './components/ListCard';
-import ActionCard from './components/ActionCard';
-import CardModal from '../../components/CardModal';
-import RequestDeletePaperModal from './components/RequestDeletePaperModal';
-import DeletePaperSuccessModal from './components/DeletePaperSuccessModal';
+import { COLOR_STYLES } from '@/constants/colorThemeStyle';
+import CardModal from '@/components/CardModal';
 import PostHeader from '@/components/PostHeader/PostHeader';
+import LoadingOverlay from '@/components/LoadingOverlay';
+import styles from '@/pages/RollingPaperItemPage/RollingPaperItemPage.module.scss';
+import ListCard from '@/pages/RollingPaperItemPage/components/ListCard';
+import ActionCard from '@/pages/RollingPaperItemPage/components/ActionCard';
+import ListButtonGroup from '@/pages/RollingPaperItemPage/components/ListButtonGroup';
+import RequestDeletePaperModal from '@/pages/RollingPaperItemPage/components/RequestDeletePaperModal';
+import DeletePaperSuccessModal from '@/pages/RollingPaperItemPage/components/DeletePaperSuccessModal';
 import InfinityScrollWrapper from '@/components/InfinityScrollWrapper/InfinityScrollWrapper';
 
 const RollingPaperItemPage = () => {
@@ -25,7 +26,7 @@ const RollingPaperItemPage = () => {
   const { data: recipientData } = useApi(getRecipient, { id }, { immediate: true });
 
   /* 커스텀훅 영역 */
-  const { itemList, hasNext, loadMore, onClickDeleteMessage, onDeletePaperConfirm } =
+  const { itemList, hasNext, loading, loadMore, onClickDeleteMessage, onDeletePaperConfirm } =
     useMessageItemsList(id); // 리스트 데이터 API 및 동작
 
   /* 전체 배경 스타일 적용 */
@@ -94,6 +95,8 @@ const RollingPaperItemPage = () => {
     <>
       {/* 헤더 영역 */}
       <PostHeader id={id} name={recipientData?.name} />
+      {/* 로딩 컴포넌트 */}
+      {loading && <LoadingOverlay description='새로운 롤링페이퍼를 만들고 있어요' />}
       <section style={containerStyle} className={styles['list']}>
         <div className={styles['list__container']}>
           <ListButtonGroup

--- a/src/pages/RollingPaperItemPage/RollingPaperItemPage.jsx
+++ b/src/pages/RollingPaperItemPage/RollingPaperItemPage.jsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { useApi } from '@/hooks/useApi.jsx';
+// import { useApi } from '@/hooks/useApi.jsx';
 import { useModal } from '@/hooks/useModal';
-import { getRecipient } from '@/apis/recipientsApi';
+// import { getRecipient } from '@/apis/recipientsApi';
 import { useMessageItemsList } from '@/hooks/useMessageItemsList';
 import { COLOR_STYLES } from '@/constants/colorThemeStyle';
 import CardModal from '@/components/CardModal';
@@ -23,12 +23,18 @@ const RollingPaperItemPage = () => {
   const [isEditMode, setIsEditMode] = useState(false);
 
   /* useApi 사용하여 API 불러오는 영역  */
-  const { data: recipientData } = useApi(getRecipient, { id }, { immediate: true });
+  // const { loading: recipientDataLoading, data: recipientData } = useApi(
+  //   getRecipient,
+  //   { id },
+  //   { immediate: true },
+  // );
 
   /* 커스텀훅 영역 */
   const {
+    recipientData,
     itemList,
     hasNext,
+    showOverlay,
     isLoading,
     loadingDescription,
     loadMore,
@@ -37,17 +43,19 @@ const RollingPaperItemPage = () => {
   } = useMessageItemsList(id); // 리스트 데이터 API 및 동작
 
   /* 전체 배경 스타일 적용 */
-  const containerStyle = {
-    backgroundColor: !recipientData?.backgroundImageURL
-      ? COLOR_STYLES[recipientData?.backgroundColor]?.primary
-      : '',
-    backgroundImage: recipientData?.backgroundImageURL
-      ? `url(${recipientData?.backgroundImageURL})`
-      : 'none',
-    backgroundRepeat: 'no-repeat',
-    backgroundPosition: 'center',
-    backgroundSize: 'cover',
-  };
+  const containerStyle = recipientData
+    ? {
+        backgroundColor: !recipientData?.backgroundImageURL
+          ? COLOR_STYLES[recipientData?.backgroundColor]?.primary
+          : '',
+        backgroundImage: recipientData?.backgroundImageURL
+          ? `url(${recipientData?.backgroundImageURL})`
+          : 'none',
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'center',
+        backgroundSize: 'cover',
+      }
+    : {};
 
   const paperDeleteModalData = {
     title: (
@@ -145,12 +153,13 @@ const RollingPaperItemPage = () => {
     );
   };
 
+  if (showOverlay || isLoading) {
+    return <LoadingOverlay description={loadingDescription} />;
+  }
   return (
     <>
       {/* 헤더 영역 */}
       <PostHeader id={id} name={recipientData?.name} />
-      {/* 로딩 컴포넌트 */}
-      {isLoading && <LoadingOverlay description={loadingDescription} />}
       <section style={containerStyle} className={styles['list']}>
         <div className={styles['list__container']}>
           <ListButtonGroup

--- a/src/pages/RollingPaperItemPage/RollingPaperItemPage.jsx
+++ b/src/pages/RollingPaperItemPage/RollingPaperItemPage.jsx
@@ -1,8 +1,6 @@
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-// import { useApi } from '@/hooks/useApi.jsx';
 import { useModal } from '@/hooks/useModal';
-// import { getRecipient } from '@/apis/recipientsApi';
 import { useMessageItemsList } from '@/hooks/useMessageItemsList';
 import { COLOR_STYLES } from '@/constants/colorThemeStyle';
 import CardModal from '@/components/CardModal';
@@ -21,13 +19,6 @@ const RollingPaperItemPage = () => {
   const { id } = useParams();
   const { showModal, closeModal } = useModal();
   const [isEditMode, setIsEditMode] = useState(false);
-
-  /* useApi 사용하여 API 불러오는 영역  */
-  // const { loading: recipientDataLoading, data: recipientData } = useApi(
-  //   getRecipient,
-  //   { id },
-  //   { immediate: true },
-  // );
 
   /* 커스텀훅 영역 */
   const {

--- a/src/pages/RollingPaperItemPage/RollingPaperItemPage.jsx
+++ b/src/pages/RollingPaperItemPage/RollingPaperItemPage.jsx
@@ -26,8 +26,15 @@ const RollingPaperItemPage = () => {
   const { data: recipientData } = useApi(getRecipient, { id }, { immediate: true });
 
   /* 커스텀훅 영역 */
-  const { itemList, hasNext, loading, loadMore, onClickDeleteMessage, onDeletePaperConfirm } =
-    useMessageItemsList(id); // 리스트 데이터 API 및 동작
+  const {
+    itemList,
+    hasNext,
+    isLoading,
+    loadingDescription,
+    loadMore,
+    onClickDeleteMessage,
+    onDeletePaperConfirm,
+  } = useMessageItemsList(id); // 리스트 데이터 API 및 동작
 
   /* 전체 배경 스타일 적용 */
   const containerStyle = {
@@ -143,7 +150,7 @@ const RollingPaperItemPage = () => {
       {/* 헤더 영역 */}
       <PostHeader id={id} name={recipientData?.name} />
       {/* 로딩 컴포넌트 */}
-      {loading && <LoadingOverlay description='새로운 롤링페이퍼를 만들고 있어요' />}
+      {isLoading && <LoadingOverlay description={loadingDescription} />}
       <section style={containerStyle} className={styles['list']}>
         <div className={styles['list__container']}>
           <ListButtonGroup

--- a/src/pages/RollingPaperItemPage/RollingPaperItemPage.jsx
+++ b/src/pages/RollingPaperItemPage/RollingPaperItemPage.jsx
@@ -21,6 +21,27 @@ const RollingPaperItemPage = () => {
   const { id } = useParams();
   const { showModal, closeModal } = useModal();
   const [isEditMode, setIsEditMode] = useState(false);
+
+  /* useApi 사용하여 API 불러오는 영역  */
+  const { data: recipientData } = useApi(getRecipient, { id }, { immediate: true });
+
+  /* 커스텀훅 영역 */
+  const { itemList, hasNext, loading, loadMore, onClickDeleteMessage, onDeletePaperConfirm } =
+    useMessageItemsList(id); // 리스트 데이터 API 및 동작
+
+  /* 전체 배경 스타일 적용 */
+  const containerStyle = {
+    backgroundColor: !recipientData?.backgroundImageURL
+      ? COLOR_STYLES[recipientData?.backgroundColor]?.primary
+      : '',
+    backgroundImage: recipientData?.backgroundImageURL
+      ? `url(${recipientData?.backgroundImageURL})`
+      : 'none',
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: 'center',
+    backgroundSize: 'cover',
+  };
+
   const paperDeleteModalData = {
     title: (
       <>
@@ -54,26 +75,6 @@ const RollingPaperItemPage = () => {
         복구할 수 없습니다.
       </>
     ),
-  };
-
-  /* useApi 사용하여 API 불러오는 영역  */
-  const { data: recipientData } = useApi(getRecipient, { id }, { immediate: true });
-
-  /* 커스텀훅 영역 */
-  const { itemList, hasNext, loading, loadMore, onClickDeleteMessage, onDeletePaperConfirm } =
-    useMessageItemsList(id); // 리스트 데이터 API 및 동작
-
-  /* 전체 배경 스타일 적용 */
-  const containerStyle = {
-    backgroundColor: !recipientData?.backgroundImageURL
-      ? COLOR_STYLES[recipientData?.backgroundColor]?.primary
-      : '',
-    backgroundImage: recipientData?.backgroundImageURL
-      ? `url(${recipientData?.backgroundImageURL})`
-      : 'none',
-    backgroundRepeat: 'no-repeat',
-    backgroundPosition: 'center',
-    backgroundSize: 'cover',
   };
 
   /* 버튼, 카드 클릭 시 동작  */

--- a/src/pages/RollingPaperItemPage/RollingPaperItemPage.jsx
+++ b/src/pages/RollingPaperItemPage/RollingPaperItemPage.jsx
@@ -21,6 +21,40 @@ const RollingPaperItemPage = () => {
   const { id } = useParams();
   const { showModal, closeModal } = useModal();
   const [isEditMode, setIsEditMode] = useState(false);
+  const paperDeleteModalData = {
+    title: (
+      <>
+        정말 이 롤링페이퍼를
+        <br />
+        <strong style={{ color: 'var(--color-purple-600)' }}>{' 삭제'}</strong>
+        하시겠습니까?
+      </>
+    ),
+    content: (
+      <>
+        삭제하면 모든 메시지가 함께 삭제되며
+        <br />
+        복구할 수 없습니다.
+      </>
+    ),
+  };
+
+  const messageDeleteModalData = {
+    title: (
+      <>
+        메시지를
+        <strong style={{ color: 'var(--color-purple-600)' }}>{' 삭제'}</strong>
+        하시겠습니까?
+      </>
+    ),
+    content: (
+      <>
+        삭제하면 메시지가 삭제되며
+        <br />
+        복구할 수 없습니다.
+      </>
+    ),
+  };
 
   /* useApi 사용하여 API 불러오는 영역  */
   const { data: recipientData } = useApi(getRecipient, { id }, { immediate: true });
@@ -64,8 +98,19 @@ const RollingPaperItemPage = () => {
   };
 
   /* 메세지 삭제 */
-  const handleOnClickDeleteMessage = () => {
-    onClickDeleteMessage();
+  const handleOnClickDeleteMessage = (messageId) => {
+    showModal(
+      <RequestDeletePaperModal
+        onConfirm={() => handleOnDeleteMessageConfirm(messageId)}
+        onCancel={closeModal}
+        modalItems={messageDeleteModalData}
+      />,
+    );
+  };
+
+  const handleOnDeleteMessageConfirm = async (messageId) => {
+    onClickDeleteMessage(messageId);
+    closeModal();
   };
 
   /* 롤링페이퍼 페이퍼 삭제 */
@@ -74,6 +119,7 @@ const RollingPaperItemPage = () => {
       <RequestDeletePaperModal
         onConfirm={() => handleOnDeletePaperConfirm()}
         onCancel={closeModal}
+        modalItems={paperDeleteModalData}
       />,
     );
   };

--- a/src/pages/RollingPaperItemPage/RollingPaperItemPage.module.scss
+++ b/src/pages/RollingPaperItemPage/RollingPaperItemPage.module.scss
@@ -5,11 +5,11 @@
   justify-content: center;
   align-items: start;
 
-  @media screen and (min-width: 768px) {
+  @include tablet {
     padding: 92px 24px;
   }
 
-  @media screen and (min-width: 1024px) {
+  @include desktop {
     padding: 113px 24px;
   }
 
@@ -31,48 +31,13 @@
     max-width: 100%;
     justify-items: center;
 
-    @media screen and (min-width: 768px) {
+    @include tablet {
       grid-template-columns: repeat(2, 1fr);
     }
 
-    @media screen and (min-width: 1024px) {
+    @include desktop {
       grid-template-columns: repeat(3, 1fr);
       gap: 24px;
     }
   }
 }
-
-.list__button {
-  left: 20px;
-  right: 20px;
-  bottom: 24px;
-  height: 56px;
-  z-index: 100;
-  border-radius: 12px;
-  background-color: var(--color-purple-600);
-  border: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--color-white);
-  font-size: var(--font-size-16);
-  font-weight: var(--font-weight-regular);
-  position: fixed;
-
-  @media screen and (min-width: 768px) {
-    left: 24px;
-    right: 24px;
-    bottom: 24px;
-  }
-
-  @media screen and (min-width: 1024px) {
-    border-radius: 6px;
-    width: 92px;
-    height: 39px;
-    position: static;
-  }
-}
-
-// .list__observer {
-//   height: 1px;
-// }

--- a/src/pages/RollingPaperItemPage/components/DeletePaperSuccessModal.module.scss
+++ b/src/pages/RollingPaperItemPage/components/DeletePaperSuccessModal.module.scss
@@ -1,84 +1,89 @@
+$wrapper-margin-x: 20px;
+
+$wrapper-width-mobile: min(350px, calc(100vw - calc($wrapper-margin-x * 2)));
+$wrapper-width-tablet: 350px;
+$wrapper-width-desktop: 350px;
+
 .modal-styler {
-	padding: 16px;
-	margin: 0 20px;
-	width: 230px;
+  padding: 16px;
+  @include responsive-width($wrapper-width-mobile, $wrapper-width-tablet, $wrapper-width-desktop);
 }
 
 .header-area {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	gap: 18px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
 }
 
 .header-icon {
-	aspect-ratio: 1 / 1;
-	width: 50px;
-	margin-top: 10px;
+  aspect-ratio: 1 / 1;
+  width: 50px;
+  margin-top: 10px;
 }
 
 .title {
-	font-weight: 700;
-	font-size: 20px;
-	color: var(--color-gray-700);
-	text-align: center;
+  font-weight: 700;
+  font-size: 20px;
+  color: var(--color-gray-700);
+  text-align: center;
 }
 
 .content {
-	width: 100%;
-	margin: 15px 0 20px;
-	text-align: center;
-	font-weight: 400;
-	font-size: 15px;
-	line-height: 20px;
-	color: var(--color-gray-400);
+  width: 100%;
+  margin: 15px 0 20px;
+  text-align: center;
+  font-weight: 400;
+  font-size: 15px;
+  line-height: 20px;
+  color: var(--color-gray-400);
 }
 
 .progress-bar {
-	margin: 0 10px 20px;
+  margin: 0 10px 20px;
 }
 
 .button-area {
-	display: flex;
-	flex-direction: row;
-	justify-content: center;
-	gap: 8px;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  gap: 8px;
 }
 
 .button__submit {
-	border-radius: 10px;
-	padding: 10px 0;
-	width: 100%;
-	text-align: center;
-	cursor: pointer;
-	font-weight: 700;
-	font-size: 16px;
-	line-height: 26px;
+  border-radius: 10px;
+  padding: 10px 0;
+  width: 100%;
+  text-align: center;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 26px;
 
-	background-color: var(--color-purple-600);
-	border: none;
-	color: var(--color-white);
+  background-color: var(--color-purple-600);
+  border: none;
+  color: var(--color-white);
 
-	&:hover{
-		background-color: var(--color-purple-700);
-	}
+  &:hover {
+    background-color: var(--color-purple-700);
+  }
 }
 
 .button__cancel {
-	border-radius: 10px;
-	padding: 10px 0;
-	width: 100%;
-	text-align: center;
-	cursor: pointer;
-	font-weight: 700;
-	font-size: 16px;
-	line-height: 26px;
+  border-radius: 10px;
+  padding: 10px 0;
+  width: 100%;
+  text-align: center;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 26px;
 
-	background-color: #E9E9E9;
-	border: none;
-	color: var(--color-gray-600);
+  background-color: #e9e9e9;
+  border: none;
+  color: var(--color-gray-600);
 
-	&:hover{
-		background-color: #E2E2E2;
-	}
+  &:hover {
+    background-color: #e2e2e2;
+  }
 }

--- a/src/pages/RollingPaperItemPage/components/ListButtonGroup.jsx
+++ b/src/pages/RollingPaperItemPage/components/ListButtonGroup.jsx
@@ -5,12 +5,13 @@ const ListButtonGroup = ({ showDelete, onClickEdit, onClickPrev, onClickGoList }
   return (
     <>
       <div className={styles['list__button-group']}>
-        <button
+        <Button onClick={onClickGoList}>목록으로</Button>
+        {/* <button
           className={`${styles['list__button']} ${styles['list__button--border']}`}
           onClick={onClickGoList}
         >
           목록으로
-        </button>
+        </button> */}
         {!showDelete && (
           <button className={styles['list__button']} onClick={onClickEdit}>
             편집하기

--- a/src/pages/RollingPaperItemPage/components/ListButtonGroup.jsx
+++ b/src/pages/RollingPaperItemPage/components/ListButtonGroup.jsx
@@ -1,26 +1,24 @@
 import styles from './ListButtonGroup.module.scss';
 import Button from '@/components/Button/Button';
+import { useDeviceType } from '@/hooks/useDeviceType';
 
 const ListButtonGroup = ({ showDelete, onClickEdit, onClickPrev, onClickGoList }) => {
+  const deviceType = useDeviceType();
   return (
     <>
       <div className={styles['list__button-group']}>
-        <Button onClick={onClickGoList}>목록으로</Button>
-        {/* <button
-          className={`${styles['list__button']} ${styles['list__button--border']}`}
-          onClick={onClickGoList}
-        >
+        <Button size={deviceType === 'desktop' ? 'small' : 'stretch'} onClick={onClickGoList}>
           목록으로
-        </button> */}
+        </Button>
         {!showDelete && (
-          <button className={styles['list__button']} onClick={onClickEdit}>
+          <Button size={deviceType === 'desktop' ? 'small' : 'stretch'} onClick={onClickEdit}>
             편집하기
-          </button>
+          </Button>
         )}
         {showDelete && (
-          <button className={styles['list__button']} onClick={onClickPrev}>
+          <Button size={deviceType === 'desktop' ? 'small' : 'stretch'} onClick={onClickPrev}>
             돌아가기
-          </button>
+          </Button>
         )}
       </div>
     </>

--- a/src/pages/RollingPaperItemPage/components/ListButtonGroup.jsx
+++ b/src/pages/RollingPaperItemPage/components/ListButtonGroup.jsx
@@ -4,19 +4,21 @@ import { useDeviceType } from '@/hooks/useDeviceType';
 
 const ListButtonGroup = ({ showDelete, onClickEdit, onClickPrev, onClickGoList }) => {
   const deviceType = useDeviceType();
+  const buttonSize = deviceType !== 'desktop' ? 'stretch' : 'small';
+
   return (
     <>
       <div className={styles['list__button-group']}>
-        <Button size={deviceType === 'desktop' ? 'small' : 'stretch'} onClick={onClickGoList}>
+        <Button size={buttonSize} onClick={onClickGoList}>
           목록으로
         </Button>
         {!showDelete && (
-          <Button size={deviceType === 'desktop' ? 'small' : 'stretch'} onClick={onClickEdit}>
+          <Button size={buttonSize} onClick={onClickEdit}>
             편집하기
           </Button>
         )}
         {showDelete && (
-          <Button size={deviceType === 'desktop' ? 'small' : 'stretch'} onClick={onClickPrev}>
+          <Button size={buttonSize} onClick={onClickPrev}>
             돌아가기
           </Button>
         )}

--- a/src/pages/RollingPaperItemPage/components/ListButtonGroup.module.scss
+++ b/src/pages/RollingPaperItemPage/components/ListButtonGroup.module.scss
@@ -7,13 +7,13 @@
   right: 20px;
   bottom: 24px;
 
-  @media screen and (min-width: 768px) {
+  @include tablet {
     left: 24px;
     right: 24px;
     bottom: 24px;
   }
 
-  @media screen and (min-width: 1024px) {
+  @include desktop {
     position: static;
   }
 }

--- a/src/pages/RollingPaperItemPage/components/ListButtonGroup.module.scss
+++ b/src/pages/RollingPaperItemPage/components/ListButtonGroup.module.scss
@@ -6,7 +6,6 @@
   left: 20px;
   right: 20px;
   bottom: 24px;
-  height: 56px;
 
   @media screen and (min-width: 768px) {
     left: 24px;
@@ -17,30 +16,4 @@
   @media screen and (min-width: 1024px) {
     position: static;
   }
-}
-
-.list__button {
-  display: flex;
-  flex: 1;
-  align-items: center;
-  justify-content: center;
-  border-radius: 12px;
-  background-color: var(--color-purple-600);
-  border: none;
-  flex: 1;
-  color: var(--color-white);
-  font-size: var(--font-size-16);
-  font-weight: var(--font-weight-regular);
-
-  @media screen and (min-width: 1024px) {
-    border-radius: 6px;
-    width: 92px;
-    height: 39px;
-  }
-}
-
-.list__button--border {
-  border: 1px solid var(--color-purple-600);
-  background: var(--color-white);
-  color: var(--color-purple-600);
 }

--- a/src/pages/RollingPaperItemPage/components/ListButtonGroup.module.scss
+++ b/src/pages/RollingPaperItemPage/components/ListButtonGroup.module.scss
@@ -17,3 +17,8 @@
     position: static;
   }
 }
+
+.list__button {
+  display: flex;
+  flex: 1;
+}

--- a/src/pages/RollingPaperItemPage/components/ListButtonGroup.module.scss
+++ b/src/pages/RollingPaperItemPage/components/ListButtonGroup.module.scss
@@ -13,7 +13,7 @@
     bottom: 24px;
   }
 
-  @include desktop {
+  @media screen and (min-width: 1024px) {
     position: static;
   }
 }

--- a/src/pages/RollingPaperItemPage/components/ListButtonGroup.module.scss
+++ b/src/pages/RollingPaperItemPage/components/ListButtonGroup.module.scss
@@ -2,7 +2,7 @@
   display: flex;
   gap: 8px;
   position: fixed;
-  z-index: 100; // 논의 필요
+  z-index: 10; // 논의 필요
   left: 20px;
   right: 20px;
   bottom: 24px;

--- a/src/pages/RollingPaperItemPage/components/ListCard.jsx
+++ b/src/pages/RollingPaperItemPage/components/ListCard.jsx
@@ -1,11 +1,16 @@
-import styles from './ListCard.module.scss';
+import styles from '@/pages/RollingPaperItemPage/components/ListCard.module.scss';
 import DeleteIcon from './DeleteIcon';
+import Button from '@/components/Button/Button';
 import SenderProfile from '@/components/SenderProfile';
 import ContentViewer from '@/components/ContentViewer/ContentViewer';
 import { FONT_STYLES } from '@/constants/fontMap';
 const ListCard = ({ cardData, showDelete, onClick, onDelete }) => {
   /* 폰트 확인 후 해당 폰트로 보여줘야 함 */
   const { id, sender, profileImageURL, content, createdAt, relationship, font } = cardData;
+
+  const deleteIconStyle = {
+    color: 'var(--color-gray-500)',
+  };
 
   const formatDateKRW = (isoString) => {
     const date = new Date(isoString);
@@ -36,9 +41,15 @@ const ListCard = ({ cardData, showDelete, onClick, onDelete }) => {
           <header className={styles['card__sender']}>
             <SenderProfile sender={sender} imageUrl={profileImageURL} relationship={relationship} />
             {showDelete && (
-              <button className={styles['card__button--delete']} onClick={onClickDeleteBtn}>
+              <Button
+                variant={'outlined'}
+                size={'40'}
+                iconOnly={true}
+                style={deleteIconStyle}
+                onClick={onClickDeleteBtn}
+              >
                 <DeleteIcon />
-              </button>
+              </Button>
             )}
           </header>
           <hr className={styles['card__divider']} />

--- a/src/pages/RollingPaperItemPage/components/ListCard.module.scss
+++ b/src/pages/RollingPaperItemPage/components/ListCard.module.scss
@@ -26,12 +26,12 @@
     transform: scale(1.05);
   }
 
-  @media screen and (min-width: 768px) {
+  @include tablet {
     aspect-ratio: 352 / 284;
     max-width: none;
   }
 
-  @media screen and (min-width: 1200px) {
+  @include desktop {
     aspect-ratio: 384 / 280;
   }
 }
@@ -72,7 +72,12 @@
   -webkit-box-orient: vertical;
   line-height: 28px;
 
-  @media screen and (min-width: 768px) {
+  @include tablet {
+    -webkit-line-clamp: 4;
+    line-clamp: 4;
+  }
+
+  @include desktop {
     -webkit-line-clamp: 4;
     line-clamp: 4;
   }

--- a/src/pages/RollingPaperItemPage/components/ListCard.module.scss
+++ b/src/pages/RollingPaperItemPage/components/ListCard.module.scss
@@ -16,8 +16,10 @@
   transform: translateZ(0);
   cursor: pointer;
 
-  &:hover {
-    transform: scale(1.05);
+  @media (hover: hover) {
+    &:hover {
+      transform: scale(1.05);
+    }
   }
 
   &:active {

--- a/src/pages/RollingPaperItemPage/components/RequestDeletePaperModal.jsx
+++ b/src/pages/RollingPaperItemPage/components/RequestDeletePaperModal.jsx
@@ -2,23 +2,16 @@ import styles from './RequestDeletePaperModal.module.scss';
 import Modal from '@/components/Modal';
 import alertIcon from '@/assets/icons/icon_alert_gray_lg.svg';
 
-const RequestDeletePaperModal = ({ onConfirm, onCancel }) => {
+const RequestDeletePaperModal = ({ onConfirm, onCancel, modalItems }) => {
+  const { title, content } = modalItems;
   return (
     <Modal className={styles['modal-styler']}>
       <Modal.headerArea className={styles['header-area']}>
         <img className={styles['header-icon']} src={alertIcon} />
-        <span className={styles['title']}>
-          정말 이 롤링페이퍼를
-          <strong style={{ color: 'var(--color-purple-600)' }}>{' 삭제'}</strong>
-          하시겠습니까?
-        </span>
+        <span className={styles['title']}>{title}</span>
       </Modal.headerArea>
       <Modal.contentArea>
-        <span className={styles['content']}>
-          삭제하면 모든 코멘트가 함께 삭제되며
-          <br />
-          복구할 수 없습니다.
-        </span>
+        <span className={styles['content']}>{content}</span>
       </Modal.contentArea>
       <Modal.buttonArea className={styles['button-area']}>
         <button className={styles['button__cancel']} onClick={onCancel}>

--- a/src/pages/RollingPaperItemPage/components/RequestDeletePaperModal.module.scss
+++ b/src/pages/RollingPaperItemPage/components/RequestDeletePaperModal.module.scss
@@ -1,79 +1,86 @@
+$wrapper-margin-x: 20px;
+
+$wrapper-width-mobile: min(350px, calc(100vw - calc($wrapper-margin-x * 2)));
+$wrapper-width-tablet: 350px;
+$wrapper-width-desktop: 350px;
+
 .modal-styler {
-	padding: 16px;
-	margin: 0 20px;
+  padding: 16px;
+  @include responsive-width($wrapper-width-mobile, $wrapper-width-tablet, $wrapper-width-desktop);
 }
 
 .header-area {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	gap: 18px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
 }
 
 .header-icon {
-	aspect-ratio: 1 / 1;
-	width: 50px;
-	margin-top: 10px;
+  aspect-ratio: 1 / 1;
+  width: 50px;
+  margin-top: 10px;
 }
 
 .title {
-	font-weight: 700;
-	font-size: 20px;
-	color: var(--color-gray-700);
-	text-align: center;
+  font-weight: 700;
+  font-size: 20px;
+  color: var(--color-gray-700);
+  text-align: center;
+  line-height: 25px;
 }
 
 .content {
-	width: 100%;
-	margin: 15px 0 20px;
-	text-align: center;
-	font-weight: 400;
-	font-size: 15px;
-	line-height: 20px;
-	color: var(--color-gray-400);
+  width: 100%;
+  margin: 15px 0 20px;
+  text-align: center;
+  font-weight: 400;
+  font-size: 15px;
+  line-height: 20px;
+  color: var(--color-gray-400);
 }
 
 .button-area {
-	display: flex;
-	flex-direction: row;
-	justify-content: center;
-	gap: 8px;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  gap: 8px;
 }
 
 .button__submit {
-	border-radius: 10px;
-	padding: 10px 0;
-	width: 100%;
-	text-align: center;
-	cursor: pointer;
-	font-weight: 700;
-	font-size: 16px;
-	line-height: 26px;
+  border-radius: 10px;
+  padding: 10px 0;
+  width: 100%;
+  text-align: center;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 26px;
 
-	background-color: var(--color-purple-600);
-	border: none;
-	color: var(--color-white);
+  background-color: var(--color-purple-600);
+  border: none;
+  color: var(--color-white);
 
-	&:hover{
-		background-color: var(--color-purple-700);
-	}
+  &:hover {
+    background-color: var(--color-purple-700);
+  }
 }
 
 .button__cancel {
-	border-radius: 10px;
-	padding: 10px 0;
-	width: 100%;
-	text-align: center;
-	cursor: pointer;
-	font-weight: 700;
-	font-size: 16px;
-	line-height: 26px;
+  border-radius: 10px;
+  padding: 10px 0;
+  width: 100%;
+  text-align: center;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 26px;
 
-	background-color: #E9E9E9;
-	border: none;
-	color: var(--color-gray-600);
+  background-color: #e9e9e9;
+  border: none;
+  color: var(--color-gray-600);
 
-	&:hover{
-		background-color: #E2E2E2;
-	}
+  &:hover {
+    background-color: #e2e2e2;
+  }
 }


### PR DESCRIPTION
## ✨ 작업 내용

### 무한 스크롤 가로 스크롤 기능 추가 (InfinityScrollWrapper)
- `isHorizontal`: props로 가로인지 확인합니다.
- `scrollObserverRef`: 스크롤할 대상을 ref로 넘겨줘야 합니다.
- 기존과 동일하게 `hasNext`, `callback` props를 전달하여 사용합니다.
- `hasNext`에는 추가 데이터가 있는지 true, false 값을 전달합니다
- `callback`에는 스크롤이 감지되었을 때 수행할 메소드를 전달합니다

### 가로 스크롤 컴포넌트 hideScroll props 추가 (HorizontalScrollContainer)
- 스크롤 숨기는 것이 기본이고 `hideScroll`이 false일 경우에만 스크롤을 보여줍니다.

### 슬라이너 컴포넌트 내 무한 스크롤 컴포넌트 추가 (Slider)
- `HorizontalScrollContainer`에 스크롤 컨테이너 감지를 위한 `scrollObserverRef `를 추가하였습니다.
- `HorizontalScrollContainer `내부에 `InfinityScrollWrapper`을 추가하였습니다.

### 리스트 페이지에 (ListPage)
- `hasNext` 변수, `loadMore` 메소드를 추가하였습니다. (*수정 필요)
- `Slider`마다 전달하여 사용 필요합니다

### 삭제/삭제 완료 모달 수정 (DeletePaperSuccessModal / RequestDeletePaperModal)
- 삭제 모달의 크기를 통일하였습니다
- `RequestDeletePaperModal`에 `modalItems` props를 추가하여 내용을 받아옵니다.

### 프로필 컴포넌트 수정 (SenderProfile)
- `from`클래스에 1줄이상인 경우 말줄임 처리되게 하였습니다.

### 롤링 상세페이지 추가 적용 사항 (RollingPaperItemPage /ListButtonGroup)
- `LoadingOverlay` 컴포넌트를 적용하였습니다
- 공통 `Button`컴포넌트를 적용하였습니다.

### reset.scss 수정
- `a 태그`에 text-decoration: none 설정하였습니다

## 🔗 관련 이슈

<!-- 예: Fixes #1 (머지 시 이슈 자동 종료) -->

Fixes #
