### PR TITLE
[HotFix]: ModalProvider 구조 수정

### DIFF
--- a/src/contexts/ModalProvider.jsx
+++ b/src/contexts/ModalProvider.jsx
@@ -13,6 +13,8 @@ export const ModalProvider = ({ children }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
 
+  const onModalCloseEventRef = useRef(null);
+
   const modalWrapperRef = useRef(null);
   const isMouseDownInsideModal = useRef(false);
 
@@ -27,17 +29,20 @@ export const ModalProvider = ({ children }) => {
 
   const pendingForClosingAnimation = () => {
     closeTimeoutRef.current = setTimeout(() => {
-      setIsOpen(false);
-      setIsClosing(false);
-      closeTimeoutRef.current = null;
+      if (isClosing) {
+        setIsOpen(false);
+        setIsClosing(false);
+        closeTimeoutRef.current = null;
+      }
     }, MODAL_CLOSE_DELAY);
   };
 
-  const showModal = (ModalComponent) => {
+  const showModal = (ModalComponent, { onModalClose } = {}) => {
     resetTimer();
     setModal(ModalComponent);
     setIsOpen(true);
     setIsClosing(false);
+    onModalCloseEventRef.current = onModalClose;
   };
 
   const closeModal = () => {
@@ -64,7 +69,12 @@ export const ModalProvider = ({ children }) => {
         !modalWrapperRef.current?.contains(e.target) &&
         isMouseDownInsideModal.current === false
       ) {
-        closeModal();
+        if (typeof onModalCloseEventRef.current === 'function') {
+          onModalCloseEventRef.current();
+          closeModal();
+        } else {
+          closeModal();
+        }
       }
     };
 


### PR DESCRIPTION
## ✨ 작업 내용

<!-- 어떤 작업을 했는지 간단히 작성해주세요 -->

### 💡 ModalProvider.jsx

현재 post/{id} 페이지에서 페이지를 삭제 한 후 삭제 완료 모달이 떠 있는 상태에서
모달 외부를 클릭하여 모달이 close 되게 만들면 list 페이지로 이동하지 않는 문제가 있습니다.

현재 modal을 사용하는 컴포넌트들에 영향을 주지 않게 만들기 위해 2번째 파라미터로 onModalClose를 전달 하도록 수정하였습니다.
따라서 기존에 작성했던 showModal 함수들은 수정하지 않아도 정상동작 합니다.
RollingPaperItemPage의 삭제완료 모달 호출하는 부분만 아래와 같이 수정하면 됩니다.
혹시 몰라서 제가 직접 수정은 안했습니다...

사용 방법

```js
      showModal(
        <DeletePaperSuccessModal
          onClose={() => {
            closeModal();
            navigate('/list');
          }}
        />,
      ),
```

```js
  const handleOnDeletePaperConfirm = async () => {
    onDeletePaperConfirm(() =>
      showModal(
        <DeletePaperSuccessModal
          onClose={() => {
            closeModal();
            navigate('/list');
          }}
        />,
// 두번째 파라미터로 `{ onModalClose: func }` 전달
        {
          onModalClose: () => {
            navigate('/list');
          },
        },
//
      ),
    );
  };

```

## 🔗 관련 이슈

<!-- 예: Fixes #1 (머지 시 이슈 자동 종료) -->

Fixes #