### PR TITLE
[Feat] 무한 스크롤 시 로딩 스피너 적용, 카드 내부 컨텐츠 잘리는 오류 수정

### DIFF
--- a/src/components/ContentViewer/ContentViewer.jsx
+++ b/src/components/ContentViewer/ContentViewer.jsx
@@ -37,7 +37,6 @@ export default function ContentViewer({
       className={className}
       style={{
         width: '100%',
-        overflow: 'auto',
         whiteSpace: 'pre-wrap',
         wordBreak: 'break-word',
 

--- a/src/components/LoadingOverlay.module.scss
+++ b/src/components/LoadingOverlay.module.scss
@@ -1,31 +1,30 @@
 .loading-overlay {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  opacity: 0.9;
+  background-color: var(--color-white);
+  z-index: 99;
 
-	width: 100%;
-	height: 100vh;
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	align-items: center;
-	position: fixed;
-	top: 0;
-	left: 0;
-	opacity: 0.9;
-	background-color: var(--color-white);
-	z-index: 99;
+  &__title {
+    font-size: 38px;
+    color: var(--color-purple-600);
+    font-weight: 700;
+    margin-top: 40px;
+    margin-bottom: 30px;
+    letter-spacing: 0.03em;
+  }
 
-	&__title {
-		font-size: 38px;
-		color: var(--color-purple-600);
-		font-weight: 700;
-		margin-top: 40px;
-		margin-bottom: 30px;
-		letter-spacing: 0.03em;
-	}
-
-	&__description {
-		font-size: 20px;
-		color: var(--color-gray-600);
-		font-weight: 700;
-		letter-spacing: 0.02em;
-	}
+  &__description {
+    font-size: 20px;
+    color: var(--color-gray-600);
+    font-weight: 700;
+    letter-spacing: 0.02em;
+  }
 }

--- a/src/hooks/useMessageItemsList.jsx
+++ b/src/hooks/useMessageItemsList.jsx
@@ -49,13 +49,6 @@ export const useMessageItemsList = (id) => {
     setItemList((prevList) => (isFirstCall || !previous ? results : [...prevList, ...results]));
   }, [messageList, isFirstCall, messageLoading]);
 
-  /* 롤링페이퍼 삭제 시 로딩 오버레이 컴포넌트 처리  */
-  // useEffect(() => {
-  //   if (deleteRecipientLoading) {
-  //     setShowOverlay(true);
-  //   }
-  // }, [deleteRecipientLoading]);
-
   /* 스크롤 시 데이터 다시 불러옴  */
   const loadMore = () => {
     if (messageLoading || !hasNext) return;
@@ -63,7 +56,7 @@ export const useMessageItemsList = (id) => {
     const newOffset = isFirstCall ? offset + 8 : offset + 6;
     getMessageListRefetch({ recipientId: id, limit: 6, offset: newOffset }).finally(() =>
       setShowInfinityLoading(false),
-    ); // 로딩 종료);
+    );
     setOffset(newOffset);
   };
 

--- a/src/pages/RollingPaperItemPage/RollingPaperItemPage.jsx
+++ b/src/pages/RollingPaperItemPage/RollingPaperItemPage.jsx
@@ -7,6 +7,7 @@ import { COLOR_STYLES } from '@/constants/colorThemeStyle';
 import CardModal from '@/components/CardModal';
 import PostHeader from '@/components/PostHeader/PostHeader';
 import LoadingOverlay from '@/components/LoadingOverlay';
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import styles from '@/pages/RollingPaperItemPage/RollingPaperItemPage.module.scss';
 import ListCard from '@/pages/RollingPaperItemPage/components/ListCard';
 import ActionCard from '@/pages/RollingPaperItemPage/components/ActionCard';
@@ -28,8 +29,8 @@ const RollingPaperItemPage = () => {
     itemList,
     hasNext,
     showOverlay,
+    showInfinityLoading,
     isLoading,
-    loadingDescription,
     loadMore,
     onClickDeleteMessage,
     onDeletePaperConfirm,
@@ -138,7 +139,7 @@ const RollingPaperItemPage = () => {
   };
 
   if (showOverlay) {
-    return <LoadingOverlay description={loadingDescription} />;
+    return <LoadingOverlay description='롤링페이퍼 메시지를 삭제하고 있어요' />;
   }
   return (
     <>
@@ -173,6 +174,11 @@ const RollingPaperItemPage = () => {
               ))}
             </div>
           </InfinityScrollWrapper>
+          {showInfinityLoading && (
+            <div className={styles['list__loading']}>
+              <LoadingSpinner.dotCircle dotCount={8} dotSize={12} distanceFromCenter={30} />
+            </div>
+          )}
         </div>
       </section>
     </>

--- a/src/pages/RollingPaperItemPage/RollingPaperItemPage.jsx
+++ b/src/pages/RollingPaperItemPage/RollingPaperItemPage.jsx
@@ -131,6 +131,7 @@ const RollingPaperItemPage = () => {
         <DeletePaperSuccessModal
           onClose={() => {
             closeModal();
+            navigate('/list');
           }}
         />,
         {
@@ -143,7 +144,7 @@ const RollingPaperItemPage = () => {
   };
 
   if (showOverlay) {
-    return <LoadingOverlay description='롤링페이퍼 메시지를 삭제하고 있어요' />;
+    return <LoadingOverlay description='롤링페이퍼를 삭제하고 있어요' />;
   }
   return (
     <>

--- a/src/pages/RollingPaperItemPage/RollingPaperItemPage.jsx
+++ b/src/pages/RollingPaperItemPage/RollingPaperItemPage.jsx
@@ -131,9 +131,13 @@ const RollingPaperItemPage = () => {
         <DeletePaperSuccessModal
           onClose={() => {
             closeModal();
-            navigate('/list');
           }}
         />,
+        {
+          onModalClose: () => {
+            navigate('/list');
+          },
+        },
       ),
     );
   };

--- a/src/pages/RollingPaperItemPage/RollingPaperItemPage.module.scss
+++ b/src/pages/RollingPaperItemPage/RollingPaperItemPage.module.scss
@@ -45,6 +45,13 @@
       gap: 24px;
     }
   }
+
+  &__loading {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    margin-top: 20px;
+  }
 }
 
 .skeleton-list {

--- a/src/pages/RollingPaperItemPage/RollingPaperItemPage.module.scss
+++ b/src/pages/RollingPaperItemPage/RollingPaperItemPage.module.scss
@@ -1,16 +1,16 @@
 .list {
   min-height: 100dvh;
-  padding: 24px 20px;
+  padding: 32px 20px;
   display: flex;
   justify-content: center;
   align-items: start;
 
   @include tablet {
-    padding: 92px 24px;
+    padding: 49px 24px;
   }
 
   @include desktop {
-    padding: 113px 24px;
+    padding: 63px 24px;
   }
 
   &__container {
@@ -48,18 +48,18 @@
 }
 
 .skeleton-list {
-	@include skeleton-style;
-	min-height: 100dvh;
-  padding: 24px 20px;
+  @include skeleton-style;
+  min-height: 100dvh;
+  padding: 32px 20px;
   display: flex;
   justify-content: center;
   align-items: start;
-	
+
   @include tablet {
-    padding: 92px 24px;
+    padding: 49px 24px;
   }
 
   @include desktop {
-    padding: 113px 24px;
+    padding: 62px 24px;
   }
 }

--- a/src/pages/RollingPaperItemPage/components/ActionCard.jsx
+++ b/src/pages/RollingPaperItemPage/components/ActionCard.jsx
@@ -8,7 +8,7 @@ const ActionCard = ({ onAction, isAdd }) => {
       {!isAdd && (
         <>
           <DeleteIcon className={`${styles['card__icon--delete']}`} />
-          <div className={`${styles['card__text--delete']}`}>게시판 삭제하기</div>
+          <div className={`${styles['card__text--delete']}`}>롤링 페이퍼 삭제하기</div>
         </>
       )}
       {isAdd && (


### PR DESCRIPTION
## ✨ 작업 내용

### 롤링 상세페이지 수정사항
- 롤링 상세페이지 삭제 팝업 `onModalClose`추가
- 카드 내부 내용이 길어지는 경우 잘리는 현상 수정 `ContentViewer` 컴포넌트 overflow: auto 속성 삭제
- 무한 스크롤 시 하단에 `LoadingSpinner` 컴포넌트 적용, `setShowInfinityLoading` 플래그로 체크합니다.
  - 데이터를 빨리 불러와서 로딩 스피너가 안보입니다. 딜레이를 줘야 할지 고민입니다.
  - 태블릿 이하 사이즈에서는 버튼에 로딩 스피너가 가려서 잘 안보이는 현상이 있습니다.

## 🔗 관련 이슈

<!-- 예: Fixes #1 (머지 시 이슈 자동 종료) -->

Fixes #
