### PR TITLE
[Refactor] Listpage에서 최초로 로딩하는 카드 개수를 20개 -> 8개로 수정

### DIFF
--- a/src/pages/ListPage/ListPage.jsx
+++ b/src/pages/ListPage/ListPage.jsx
@@ -37,7 +37,7 @@ const ListPage = () => {
     refetch: getRecentList,
   } = useApi(
     listRecipients,
-    { limit: 20, offset: recentOffset, sortLike: false },
+    { limit: 8, offset: recentOffset, sortLike: false },
     {
       errorMessage: '최근 롤링페이퍼 목록을 불러오는 데 실패했습니다.',
       retry: 1,
@@ -74,9 +74,9 @@ const ListPage = () => {
   // 최신 카드 추가 로드 함수
   const loadMoreRecent = () => {
     if (recentLoading || !recentHasNext) return;
-    const newOffset = recentOffset + 20;
+    const newOffset = recentOffset + 8;
     setRecentOffset(newOffset);
-    getRecentList({ limit: 20, offset: newOffset, sortLike: false });
+    getRecentList({ limit: 8, offset: newOffset, sortLike: false });
   };
 
   return (


### PR DESCRIPTION
## ✨ 작업 내용

<!-- 어떤 작업을 했는지 간단히 작성해주세요 -->

- 기존에 20개를 로딩했는데, 저희 현재 작성된 카드 수가 적어서 무한 스크롤 및 추가 카드 로딩 기능이 구현하는 것이 시연 영상에 담기지 않을 것 같아서 8개로 줄였습니다.

## 🔗 관련 이슈

<!-- 예: Fixes #1 (머지 시 이슈 자동 종료) -->

Fixes #
